### PR TITLE
effect_performer idea

### DIFF
--- a/effect/_sync.py
+++ b/effect/_sync.py
@@ -63,3 +63,28 @@ def sync_performer(f):
         except:
             box.fail(sys.exc_info())
     return sync_wrapper
+
+
+def effect_performer(f):
+    """
+    A decorator for performers that return effect
+
+    The function being decorated is expected to take a dispatcher and an intent
+    (and not a box), and should return (dispatcher, effect) tuple. The returned
+    effect will be performed using returned dispatcher.
+
+    Example::
+
+        @effect_performer
+        def perform_foo(dispatcher, foo):
+            new_disp = ComposedDispatcher(
+                [special_dispatcher(foo.fields), dispatcher])
+            return new_disp, foo.effect
+    """
+    @wraps(f)
+    def eff_wrapper(*args):
+        box = args[-1]
+        pass_args = args[:-1]
+        new_disp, eff = f(*pass_args)
+        perform(new_disp, eff, eff.on(box.succeed, box.fail))
+    return eff_wrapper


### PR DESCRIPTION
A performer for intents that return effect. This is idea I had. Will add tests after initial review. For example, [tenant scope performer](https://github.com/rackerlabs/otter/blob/master/otter/cloud_client.py#L281-L303) can be written as:

``` python
@effect_performer
def perform_tenant_scope(
        authenticator, log, service_configs, throttler,
        dispatcher, tenant_scope,
        _concretize=concretize_service_request):
    """
    Perform a :obj:`TenantScope` by performing its :attr:`TenantScope.effect`,
    with a dispatcher extended with a performer for :obj:`ServiceRequest`
    intents. The performer will use the tenant provided by the
    :obj:`TenantScope`.
    """
    @sync_performer
    def scoped_performer(dispatcher, service_request):
        return _concretize(
            authenticator, log, service_configs, throttler,
            tenant_scope.tenant_id, service_request)
    new_disp = ComposedDispatcher([
        TypeDispatcher({ServiceRequest: scoped_performer}),
        dispatcher])
    return new_disp, tenant_scope.effect
```
