### PR TITLE
re-raise StopIteration unless it comes directly from the @do-wrapped generator

### DIFF
--- a/effect/do.py
+++ b/effect/do.py
@@ -27,11 +27,12 @@ def do(f):
         eff = foo()
         return eff.on(...)
 
-    ``@do`` must decorate a generator function. Any yielded values must either
-    be Effects or the result of a :func:`do_return` call. The result of a
-    yielded Effect will be passed back into the generator as the result of the
-    ``yield`` expression. Yielded :func:`do_return` values will provide the
-    ultimate result of the Effect that is returned by the decorated function.
+    ``@do`` must decorate a generator function (not any other type of
+    iterator). Any yielded values must either be Effects or the result of a
+    :func:`do_return` call. The result of a yielded Effect will be passed back
+    into the generator as the result of the ``yield`` expression. Yielded
+    :func:`do_return` values will provide the ultimate result of the Effect
+    that is returned by the decorated function.
 
     It's important to note that any generator function decorated by ``@do``
     will no longer return a generator, but instead it will return an Effect,


### PR DESCRIPTION
This is a fix for #36. There may be some edge cases I'm missing, so it'd be good if someone else can take a look.