### PR TITLE
perform_sequence: a higher-level, more debuggable way to perform with a SequenceDispatcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 lint:
-	flake8 --ignore=E131,E731,W503 effect/
+	flake8 --ignore=E131,E731,W503 --max-line-length=100 effect/
 
 build-dist:
 	rm -rf dist

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,4 +14,4 @@ project = u'Effect'
 copyright = u'2015, Christopher Armstrong'
 version = release = '0.9+'
 
-
+html_theme = 'sphinx_rtd_theme'

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -2,7 +2,7 @@ Testing Effectful Code
 ----------------------
 
 The most useful testing tool you'll want to familiarize yourself with is
-:obj:`effect.testing.SequenceDispatcher`. Using this with
-:func:`effect.sync_perform` in your unit tests will allow you to perform your
-effects while both ensuring that the expected intents are performed, as well as
-provide the results of those effects.
+:func:`effect.testing.perform_sequence`. Using this in your unit tests will
+allow you to perform your effects while ensuring that the expected intents are
+performed in the expected order, as well as provide the results of those
+effects.

--- a/effect/do.py
+++ b/effect/do.py
@@ -63,6 +63,10 @@ def do(f):
                     % (f, gen))
             return _do(None, gen, False)
 
+        fname = getattr(f, '__name__', None)
+        if fname is not None:
+            doit.__name__ = 'do_' + fname
+
         return Effect(Func(doit))
     return do_wrapper
 

--- a/effect/test_fold.py
+++ b/effect/test_fold.py
@@ -3,9 +3,7 @@ import operator
 
 from pytest import raises
 
-from effect import (
-    ComposedDispatcher, Effect, Error,
-    base_dispatcher, sync_perform)
+from effect import Effect, Error, base_dispatcher, sync_perform
 from effect.fold import FoldError, fold_effect, sequence
 from effect.testing import perform_sequence
 

--- a/effect/test_fold.py
+++ b/effect/test_fold.py
@@ -7,12 +7,7 @@ from effect import (
     ComposedDispatcher, Effect, Error,
     base_dispatcher, sync_perform)
 from effect.fold import FoldError, fold_effect, sequence
-from effect.testing import SequenceDispatcher
-
-
-def _base_and(dispatcher):
-    """Compose base_dispatcher onto the given dispatcher."""
-    return ComposedDispatcher([dispatcher, base_dispatcher])
+from effect.testing import perform_sequence
 
 
 def test_fold_effect():
@@ -22,15 +17,13 @@ def test_fold_effect():
     """
     effs = [Effect('a'), Effect('b'), Effect('c')]
 
-    dispatcher = SequenceDispatcher([
+    dispatcher = [
         ('a', lambda i: 'Ei'),
         ('b', lambda i: 'Bee'),
         ('c', lambda i: 'Cee'),
-    ])
+    ]
     eff = fold_effect(operator.add, 'Nil', effs)
-
-    with dispatcher.consume():
-        result = sync_perform(_base_and(dispatcher), eff)
+    result = perform_sequence(dispatcher, eff)
     assert result == 'NilEiBeeCee'
 
 
@@ -50,15 +43,12 @@ def test_fold_effect_errors():
     """
     effs = [Effect('a'), Effect(Error(ZeroDivisionError('foo'))), Effect('c')]
 
-    dispatcher = SequenceDispatcher([
-        ('a', lambda i: 'Ei'),
-    ])
+    dispatcher = [('a', lambda i: 'Ei')]
 
     eff = fold_effect(operator.add, 'Nil', effs)
 
-    with dispatcher.consume():
-        with raises(FoldError) as excinfo:
-            sync_perform(_base_and(dispatcher), eff)
+    with raises(FoldError) as excinfo:
+        perform_sequence(dispatcher, eff)
     assert excinfo.value.accumulator == 'NilEi'
     assert excinfo.value.wrapped_exception[0] is ZeroDivisionError
     assert str(excinfo.value.wrapped_exception[1]) == 'foo'
@@ -67,14 +57,11 @@ def test_fold_effect_errors():
 def test_fold_effect_str():
     """str()ing a FoldError returns useful traceback/exception info."""
     effs = [Effect('a'), Effect(Error(ZeroDivisionError('foo'))), Effect('c')]
-    dispatcher = SequenceDispatcher([
-        ('a', lambda i: 'Ei'),
-    ])
+    dispatcher = [('a', lambda i: 'Ei')]
 
     eff = fold_effect(operator.add, 'Nil', effs)
-    with dispatcher.consume():
-        with raises(FoldError) as excinfo:
-            sync_perform(_base_and(dispatcher), eff)
+    with raises(FoldError) as excinfo:
+        perform_sequence(dispatcher, eff)
     assert str(excinfo.value).startswith(
         "<FoldError after accumulating 'NilEi'> Original traceback follows:\n")
     assert str(excinfo.value).endswith('ZeroDivisionError: foo')
@@ -83,15 +70,14 @@ def test_fold_effect_str():
 def test_sequence():
     """Collects each Effectful result into a list."""
     effs = [Effect('a'), Effect('b'), Effect('c')]
-    dispatcher = SequenceDispatcher([
+    dispatcher = [
         ('a', lambda i: 'Ei'),
         ('b', lambda i: 'Bee'),
         ('c', lambda i: 'Cee'),
-    ])
+    ]
     eff = sequence(effs)
 
-    with dispatcher.consume():
-        result = sync_perform(_base_and(dispatcher), eff)
+    result = perform_sequence(dispatcher, eff)
     assert result == ['Ei', 'Bee', 'Cee']
 
 
@@ -107,15 +93,12 @@ def test_sequence_error():
     """
     effs = [Effect('a'), Effect(Error(ZeroDivisionError('foo'))), Effect('c')]
 
-    dispatcher = SequenceDispatcher([
-        ('a', lambda i: 'Ei'),
-    ])
+    dispatcher = [('a', lambda i: 'Ei')]
 
     eff = sequence(effs)
 
-    with dispatcher.consume():
-        with raises(FoldError) as excinfo:
-            sync_perform(_base_and(dispatcher), eff)
+    with raises(FoldError) as excinfo:
+        perform_sequence(dispatcher, eff)
     assert excinfo.value.accumulator == ['Ei']
     assert excinfo.value.wrapped_exception[0] is ZeroDivisionError
     assert str(excinfo.value.wrapped_exception[1]) == 'foo'

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -364,9 +364,11 @@ class SequenceDispatcherTests(TestCase):
 class MyIntent(object):
     val = attr.ib()
 
+
 @attr.s
 class OtherIntent(object):
     val = attr.ib()
+
 
 def test_perform_sequence():
     """perform_sequence pretty much acts like SequenceDispatcher by default."""

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -69,12 +69,12 @@ def perform_sequence(seq, eff, fallback_dispatcher=None):
     ``AssertionError`` is raised with a log of all intents that were performed
     so far. Each item in the log starts with one of three prefixes:
 
-    - sequence: this intent was found in the sequence
-    - fallback: a performer for this intent was provided by the fallback
-        dispatcher
-    - NOT FOUND: no performer for this intent was found.
+    * ``sequence``: this intent was found in the sequence
+    * ``fallback``: a performer for this intent was provided by the fallback
+      dispatcher
+    * ``NOT FOUND``: no performer for this intent was found.
 
-    :param list sequence: Sequence of ``(intent, fn)``, where ``fn`` is a
+    :param list sequence: List of ``(intent, fn)`` tuples, where ``fn`` is a
         function that should accept an intent and return a result.
     :param Effect eff: The Effect to perform.
     :param fallback_dispatcher: A dispatcher to use for intents that aren't

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -82,8 +82,7 @@ def perform_sequence(seq, eff, fallback_dispatcher=None):
         used.
     """
     def fmt_log():
-        return '{{{\n%s\n}}}' % (
-            '\n'.join(['{}: {}'.format(*x) for x in log]),)
+        return '{{{\n%s\n}}}' % ('\n'.join(['%s: %s' % x for x in log]),)
 
     def dispatcher(intent):
         p = sequence(intent)
@@ -97,7 +96,7 @@ def perform_sequence(seq, eff, fallback_dispatcher=None):
         else:
             log.append(("NOT FOUND", intent))
             raise AssertionError(
-                "Performer not found: {}! Log follows:\n{}".format(
+                "Performer not found: %s! Log follows:\n%s" % (
                     intent, fmt_log()))
 
     if fallback_dispatcher is None:


### PR DESCRIPTION
The main benefit over SequenceDispatcher is:

- you don't need the `with`, since it performs the effect for you
- it generates a log of intents that were performed (or failed to be performed). omg!