### PR TITLE
Test helper functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 install:
     - pip install .
     - pip install -r dev-requirements.txt
-    - pip install sphinx
+    - pip install sphinx sphinx_rtd_theme
 script:
     - make lint
     - py.test

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -27,7 +27,10 @@ from .testing import (
     EQDispatcher,
     EQFDispatcher,
     SequenceDispatcher,
+    const,
+    conste,
     fail_effect,
+    intent_func,
     parallel_sequence,
     perform_sequence,
     resolve_effect,
@@ -462,3 +465,30 @@ def test_parallel_sequence_must_be_parallel():
     with pytest.raises(FoldError) as excinfo:
         perform_sequence(seq, p)
     assert excinfo.value.wrapped_exception[0] is AssertionError
+
+
+def test_const():
+    """
+    :func:`const` takes an argument but returns fixed value
+    """
+    assert const(2)(MyIntent("whatever")) == 2
+    assert const("text")(OtherIntent("else")) == "text"
+
+
+def test_conste():
+    """
+    :func:`conste` takes an argument but always raises given exception
+    """
+    func = conste(ValueError("boo"))
+    with pytest.raises(ValueError):
+        func(MyIntent("yo"))
+
+
+def test_intent_func():
+    """
+    :func:`intent_func` returns function that returns Effect of tuple of passed arg
+    and its args.
+    """
+    func = intent_func("myfunc")
+    assert func(2, 3) == Effect(("myfunc", 2, 3))
+    assert func("text", 3, None) == Effect(("myfunc", "text", 3, None))

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -164,6 +164,7 @@ def parallel_sequence(parallel_seqs, fallback_dispatcher=None):
         sequence dispatcher.
     """
     perf = partial(perform_sequence, fallback_dispatcher=fallback_dispatcher)
+
     def performer(intent):
         if len(intent.effects) != len(parallel_seqs):
             raise AssertionError(


### PR DESCRIPTION
Some test related helper functions that we've been using in https://github.com/rackerlabs/otter/ for a long time.