### PR TITLE
Iter performer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ effect.egg-info/
 dist/
 *~
 .pytest_cache
+
+# vim
+*.sw[a-p]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ flake8
 pytest
 sphinx
 sphinx-rtd-theme
+toolz

--- a/effect/iter_performer.py
+++ b/effect/iter_performer.py
@@ -1,7 +1,7 @@
 from toolz import curry
 from functools import partial
 from effect import Effect, sync_performer
-from effect.do import do
+from effect.do import do, do_return
 
 
 def iterator_performer(xs=None):
@@ -27,8 +27,9 @@ def iterator_performer(xs=None):
 def iter_retriever(retrieval_type, f):
     """Appends retrieval of values from continuation at the end of function"""
     def perform(gen):
-        yield from gen
-        return Effect(retrieval_type())
+        for value in gen:
+            yield value
+        yield do_return(Effect(retrieval_type()))
 
     @curry
     def fixed_point(f, arg):
@@ -42,6 +43,7 @@ def iter_retriever__uncurried(retrieval_type, f):
     """Uncurried version of the above - much less generic!"""
     @do
     def wrapper(*args, **kwargs):
-        yield from f(*args, **kwargs)
-        return Effect(retrieval_type())
+        for value in f(*args, **kwargs):
+            yield value
+        yield do_return(Effect(retrieval_type()))
     return wrapper

--- a/effect/iter_performer.py
+++ b/effect/iter_performer.py
@@ -1,0 +1,55 @@
+import typing as t
+from toolz import curry
+from itertools import chain
+from effect import Effect, sync_performer
+from effect.do import do
+
+T = t.TypeVar('T')
+
+
+def iterator_performer(xs: t.Iterable[T] = None) -> t.Tuple[t.Callable,
+                                                            t.Callable]:
+    """
+    Returns performers for isolating iterator among other effects.
+    For exemplary usages one may look into tests.
+    """
+    xs = xs if xs is not None else []
+    @sync_performer
+    def performer(dispatcher, intent: T) -> None:
+        """Chains yielded values and stores them in continuation"""
+        nonlocal xs
+        xs = chain(xs, [intent])
+
+    @sync_performer
+    def retriever(dispatcher, intent: T) -> t.Iterable[T]:
+        """Provides retrieval of gathered values"""
+        nonlocal xs
+        return xs
+
+    return performer, retriever
+
+
+@curry
+def iter_retriever(retrieval_type, f):
+    """Appends retrieval of values from continuation at the end of function"""
+    @curry
+    def aux(f, arg):
+        f = f(arg)
+        if callable(f):
+            return aux(f)
+
+        def perform():
+            yield from f
+            return Effect(retrieval_type())
+        return do(perform)()
+    return aux(f)
+
+
+@curry
+def iter_retriever__uncurried(retrieval_type, f):
+    """Uncurried version of the above - much less generic!"""
+    @do
+    def wrapper(*args, **kwargs):
+        yield from f(*args, **kwargs)
+        return Effect(retrieval_type())
+    return wrapper

--- a/effect/iter_performer.py
+++ b/effect/iter_performer.py
@@ -1,5 +1,4 @@
 from toolz import curry
-from itertools import chain
 from functools import partial
 from effect import Effect, sync_performer
 from effect.do import do

--- a/effect/iter_performer.py
+++ b/effect/iter_performer.py
@@ -1,27 +1,23 @@
-import typing as t
 from toolz import curry
 from itertools import chain
 from effect import Effect, sync_performer
 from effect.do import do
 
-T = t.TypeVar('T')
 
-
-def iterator_performer(xs: t.Iterable[T] = None) -> t.Tuple[t.Callable,
-                                                            t.Callable]:
+def iterator_performer(xs=None):
     """
     Returns performers for isolating iterator among other effects.
     For exemplary usages one may look into tests.
     """
     xs = xs if xs is not None else []
     @sync_performer
-    def performer(dispatcher, intent: T) -> None:
+    def performer(dispatcher, intent):
         """Chains yielded values and stores them in continuation"""
         nonlocal xs
         xs = chain(xs, [intent])
 
     @sync_performer
-    def retriever(dispatcher, intent: T) -> t.Iterable[T]:
+    def retriever(dispatcher, intent):
         """Provides retrieval of gathered values"""
         nonlocal xs
         return xs

--- a/effect/test_iter_performer.py
+++ b/effect/test_iter_performer.py
@@ -1,5 +1,5 @@
-import typing as t
 import unittest
+from collections import namedtuple
 from toolz import curry
 from effect.do import do
 from effect import (Effect, sync_perform, sync_performer, TypeDispatcher,
@@ -8,9 +8,9 @@ from .iter_performer import (iterator_performer, iter_retriever,
                              iter_retriever__uncurried)
 
 
-Value = t.NamedTuple('Value', [('text', str)])
-RetrieveValues = t.NamedTuple('RetrieveValues', [])
-LaunchRockets = t.NamedTuple('LaunchRockets', [])
+Value = namedtuple('Value', ['text'])
+RetrieveValues = namedtuple('RetrieveValues', [])
+LaunchRockets = namedtuple('LaunchRockets', [])
 
 
 @sync_performer
@@ -34,7 +34,7 @@ def get_iter_dispatcher():
 value_retriever = iter_retriever(RetrieveValues)
 
 
-def sync_perform_iter(e: Effect):
+def sync_perform_iter(e):
     return sync_perform(get_iter_dispatcher(), e)
 
 

--- a/effect/test_iter_performer.py
+++ b/effect/test_iter_performer.py
@@ -1,9 +1,9 @@
 import unittest
 from collections import namedtuple
 from toolz import curry
-from effect.do import do
 from effect import (Effect, sync_perform, sync_performer, TypeDispatcher,
                     ComposedDispatcher, base_dispatcher)
+from .do import do, do_return
 from .iter_performer import (iterator_performer, iter_retriever,
                              iter_retriever__uncurried)
 
@@ -52,7 +52,7 @@ class IteratorPerformerTestCase(unittest.TestCase):
             yield Effect(self.values_list[0])
             yield Effect(self.values_list[1])
             yield Effect(self.values_list[2])
-            return Effect(RetrieveValues())
+            yield do_return(Effect(RetrieveValues()))
         effect = f(42)
         yielded_values = list(sync_perform_iter(effect))
         self.assertEqual(self.values_list, yielded_values)

--- a/effect/test_iter_performer.py
+++ b/effect/test_iter_performer.py
@@ -1,0 +1,101 @@
+import typing as t
+import unittest
+from toolz import curry
+from effect.do import do
+from effect import (Effect, sync_perform, sync_performer, TypeDispatcher,
+                    ComposedDispatcher, base_dispatcher)
+from .iter_performer import (iterator_performer, iter_retriever,
+                             iter_retriever__uncurried)
+
+
+Value = t.NamedTuple('Value', [('text', str)])
+RetrieveValues = t.NamedTuple('RetrieveValues', [])
+LaunchRockets = t.NamedTuple('LaunchRockets', [])
+
+
+@sync_performer
+def launch_rockets_performer(dispatcher, intent):
+    # I don't really do that
+    pass
+
+
+def get_iter_dispatcher():
+    iter_performer, iter_retriever = iterator_performer([])
+    return ComposedDispatcher([
+        TypeDispatcher({
+            Value: iter_performer,
+            RetrieveValues: iter_retriever,
+            LaunchRockets: launch_rockets_performer,
+        }),
+        base_dispatcher,
+    ])
+
+
+value_retriever = iter_retriever(RetrieveValues)
+
+
+def sync_perform_iter(e: Effect):
+    return sync_perform(get_iter_dispatcher(), e)
+
+
+class IteratorPerformerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.values_list = [
+            Value('be like'),
+            Value('water'),
+            Value('my friend'),
+        ]
+
+    def test_iterator_performer(self):
+        @do
+        def f(x):
+            yield Effect(self.values_list[0])
+            yield Effect(self.values_list[1])
+            yield Effect(self.values_list[2])
+            return Effect(RetrieveValues())
+        effect = f(42)
+        yielded_values = list(sync_perform_iter(effect))
+        self.assertEqual(self.values_list, yielded_values)
+
+    def test_iter_decorator(self):
+        @value_retriever
+        def f(x):
+            yield Effect(self.values_list[0])
+            yield Effect(self.values_list[1])
+            yield Effect(self.values_list[2])
+        effect = f(42)
+        yielded_values = list(sync_perform_iter(effect))
+        self.assertEqual(self.values_list, yielded_values)
+
+    def test_iter_decorator__curried(self):
+        @value_retriever
+        @curry
+        def f(x, y, z):
+            yield Effect(self.values_list[0])
+            yield Effect(self.values_list[1])
+            yield Effect(self.values_list[2])
+        effect = f("x")("y")("z")
+        yielded_values = list(sync_perform_iter(effect))
+        self.assertEqual(self.values_list, yielded_values)
+
+    def test_iter_decorator__uncurried(self):
+        @iter_retriever__uncurried(RetrieveValues)
+        def f(x, y, z):
+            yield Effect(self.values_list[0])
+            yield Effect(self.values_list[1])
+            yield Effect(self.values_list[2])
+        effect = f("x", "y", "z")
+        yielded_values = list(sync_perform_iter(effect))
+        self.assertEqual(self.values_list, yielded_values)
+
+    def test_iter_decorator__other_effects(self):
+        @value_retriever
+        def f(x):
+            yield Effect(LaunchRockets())
+            yield Effect(self.values_list[0])
+            yield Effect(self.values_list[1])
+            yield Effect(LaunchRockets())
+            yield Effect(self.values_list[2])
+        effect = f(42)
+        yielded_values = list(sync_perform_iter(effect))
+        self.assertEqual(self.values_list, yielded_values)


### PR DESCRIPTION
Hello. I've found myself in need to have actual generators among the effectful code - or in other words, to have a standard python generator that uses effects. This library already relies on `yield` syntax, so it's not straighforward, and thus I wrote a peformer to do that.

I think that the code turned out to be generic enough to (maybe) be incorporated into the upstream - the need for actual generators seems like a simple and reocurring thing.

Obvious issues with the PR:
- more docs would be helpful
- not following all code conventions (for instance you use `testtools` for testing)
- added `toolz` - I don't really need it, since I only use `curry` from there. This could be rewritten to `partial`s to cut the dependency.

I did not bother myself yet to address these issues. Instead, at first I would like to hear your opinion and whether you would like to see something like that in the repo, and then I can polish the details. Tests are here natural usage examples.