### PR TITLE
[BACKWARDS INCOMPATIBLE] Use exception instances instead of exc_info tuples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install -r dev-requirements.txt
     - pip install sphinx sphinx_rtd_theme
 script:
-    - make lint
+    - flake8
     - py.test
     - make doc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
-    - "pypy"
+    - "pypy3"
 install:
     - pip install .
     - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,10 @@ sudo: false
 
 language: python
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
     - "pypy"
-matrix:
-    include:
-        - python: 3.7
-          dist: xenial
-          sudo: true
 install:
     - pip install .
     - pip install -r dev-requirements.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\radix\\.virtualenvs\\effect\\Scripts\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\radix\\.virtualenvs\\effect\\Scripts\\python.exe"
-}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-lint:
-	flake8 --ignore=E131,E301,E302,E731,W503,E701,E704,E722 --max-line-length=100 effect/
-
 build-dist:
 	rm -rf dist
 	python setup.py sdist bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ the effects (that is, IO or state manipulation) in your code. Documentation is
 available at https://effect.readthedocs.org/, and its PyPI page is
 https://pypi.python.org/pypi/effect.
 
-It `supports`_ Python 2.7, 3.4 and 3.5 as well as PyPy.
+It `supports`_ 3.6 and above.
 
 .. _`supports`: https://travis-ci.org/python-effect/effect
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,6 @@ A very quick example of using Effects:
 
 .. code:: python
 
-    from __future__ import print_function
     from effect import sync_perform, sync_performer, Effect, TypeDispatcher
 
     class ReadLine(object):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ Effect
 Effect is a library for helping you write purely functional code by
 isolating the effects (that is, IO or state manipulation) in your code.
 
-It supports both Python 2.6 and up, and 3.4 and up, as well as PyPy.
+It supports both Python 3.6 and up, as well as PyPy.
 
 It lives on PyPI at https://pypi.python.org/pypi/effect and GitHub at
 https://github.com/python-effect/effect.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -47,7 +47,7 @@ the ``on`` method:
     def greet():
         return get_user_name().on(
             success=lambda r: Effect(Print("Hello,", r)),
-            error=lambda exc_info: Effect(Print("There was an error!", exc_info[1])))
+            error=lambda exc: Effect(Print("There was an error!", exc)))
 
 
 (Here we assume another intent, ``Print``, which shows some text to the user.)

--- a/effect/__init__.py
+++ b/effect/__init__.py
@@ -7,8 +7,6 @@ have the general benefits of purely functional code).
 See https://effect.readthedocs.org/ for documentation.
 """
 
-from __future__ import absolute_import
-
 from ._base import Effect, perform, NoPerformerFoundError, catch, raise_
 from ._sync import (
     NotSynchronousError,

--- a/effect/_base.py
+++ b/effect/_base.py
@@ -1,6 +1,4 @@
 # -*- test-case-name: effect.test_base -*-
-from __future__ import print_function, absolute_import
-
 from functools import partial
 
 import attr

--- a/effect/_base.py
+++ b/effect/_base.py
@@ -2,12 +2,9 @@
 from __future__ import print_function, absolute_import
 
 import sys
-
 from functools import partial
 
 import attr
-
-import six
 
 from ._continuation import trampoline
 
@@ -34,8 +31,7 @@ class Effect(object):
         The result of the Effect will be passed to the first callback. Any
         callbacks added afterwards will receive the result of the previous
         callback. Normal return values are passed on to the next ``success``
-        callback, and exceptions are passed to the next ``error`` callback
-        as a ``sys.exc_info()`` tuple.
+        callback, and exceptions are passed to the next ``error`` callback.
 
         If a callback returns an :obj:`Effect`, the result of that
         :obj:`Effect` will be passed to the next callback.
@@ -62,7 +58,7 @@ class _Box(object):
 
     def fail(self, result):
         """
-        Indicate that the effect has failed. result must be an exc_info tuple.
+        Indicate that the effect has failed. result must be an exception.
         """
         self._cont((True, result))
 
@@ -71,13 +67,13 @@ def guard(f, *args, **kwargs):
     """
     Run a function.
 
-    Return (is_error, result), where is_error is a boolean indicating whether
-    it raised an exception. In that case result will be ``sys.exc_info()``.
+    Return (is_error, result), where ``is_error`` is a boolean indicating whether
+    it raised an exception. In that case, ``result`` will be an exception.
     """
     try:
         return (False, f(*args, **kwargs))
-    except:
-        return (True, sys.exc_info())
+    except Exception as e:
+        return (True, e)
 
 
 class NoPerformerFoundError(Exception):
@@ -110,7 +106,7 @@ def perform(dispatcher, effect):
     or return another Effect, which will be recursively performed, such that
     the result of the returned Effect becomes the result passed to the next
     callback. In the case of exceptions, the next error-callback will be called
-    with a ``sys.exc_info()``-style tuple.
+    with the exception instance.
 
     :returns: None
 
@@ -123,9 +119,8 @@ def perform(dispatcher, effect):
        passed three arguments, not two: the dispatcher, the intent, and a
        "box". The box is an object that lets the performer provide the result,
        optionally asynchronously. To provide the result, use
-       ``box.succeed(result)`` or ``box.fail(exc_info)``, where ``exc_info`` is
-       a ``sys.exc_info()``-style tuple. Decorators like :func:`sync_performer`
-       simply abstract this away.
+       ``box.succeed(result)`` or ``box.fail(exc)``, where ``exc`` is
+       an exception. Decorators like :func:`sync_performer` simply abstract this away.
     """
     def _run_callbacks(bouncer, chain, result):
         is_error, value = result
@@ -156,8 +151,7 @@ def perform(dispatcher, effect):
                     effect.intent,
                     _Box(partial(bouncer.bounce,
                                  _run_callbacks, effect.callbacks)))
-        except:
-            e = sys.exc_info()
+        except Exception as e:
             _run_callbacks(bouncer, effect.callbacks, (True, e))
 
     trampoline(_perform, effect)
@@ -168,27 +162,25 @@ def catch(exc_type, callable):
     A helper for handling errors of a specific type::
 
         eff.on(error=catch(SpecificException,
-                           lambda exc_info: "got an error!"))
+                           lambda exc: "got an error!"))
 
     If any exception other than a ``SpecificException`` is thrown, it will be
     ignored by this handler and propogate further down the chain of callbacks.
     """
-    def catcher(exc_info):
-        if isinstance(exc_info[1], exc_type):
-            return callable(exc_info)
-        six.reraise(*exc_info)
+    def catcher(error):
+        if isinstance(error, exc_type):
+            return callable(error)
+        raise error
     return catcher
 
 
-def raise_(exception, tb=None):
-    """Simple convenience function to allow raising exceptions from lambdas.
-
-    This is slightly more convenient than ``six.reraise`` because it takes an
-    exception instance instead of needing the type separate from the instance.
+def raise_(exception):
+    """Simple convenience function to allow raising exceptions as an expression,
+    useful in lambdas.
 
     :param exception: An exception *instance* (not an exception type).
 
-    - ``raise_(exc)`` is the same as ``raise exc``.
-    - ``raise_(exc, tb)`` is the same as ``raise type(exc), exc, tb``.
+    ``raise_(exc)`` is the same as ``raise exc``.
     """
-    six.reraise(type(exception), exception, tb)
+    raise exception
+

--- a/effect/_base.py
+++ b/effect/_base.py
@@ -1,7 +1,6 @@
 # -*- test-case-name: effect.test_base -*-
 from __future__ import print_function, absolute_import
 
-import sys
 from functools import partial
 
 import attr
@@ -183,4 +182,3 @@ def raise_(exception):
     ``raise_(exc)`` is the same as ``raise exc``.
     """
     raise exception
-

--- a/effect/_dispatcher.py
+++ b/effect/_dispatcher.py
@@ -4,8 +4,6 @@ Dispatcher!
 
 import attr
 
-from six.moves import filter
-
 
 @attr.s
 class TypeDispatcher(object):

--- a/effect/_intents.py
+++ b/effect/_intents.py
@@ -77,7 +77,7 @@ def parallel_all_errors(effects):
     :param effects: Effects which should be performed in parallel.
     :return: An Effect that results in a list of ``(is_error, result)`` tuples,
         where ``is_error`` is True if the child effect raised an exception, in
-        which case ``result`` will be an exc_info tuple. If ``is_error`` is
+        which case ``result`` will be the exception. If ``is_error`` is
         False, then ``result`` will just be the result as provided by the child
         effect.
     """
@@ -93,12 +93,12 @@ class FirstError(Exception):
     One of the effects in a :obj:`ParallelEffects` resulted in an error. This
     represents the first such error that occurred.
     """
-    exc_info = attr.ib()
+    exception = attr.ib()
     index = attr.ib()
 
     def __str__(self):
         return '(index=%s) %s: %s' % (
-            self.index, self.exc_info[0].__name__, self.exc_info[1])
+            self.index, type(self.exception).__name__, self.exception)
 
 
 @attr.s

--- a/effect/_intents.py
+++ b/effect/_intents.py
@@ -8,9 +8,6 @@ standard performers for intents which really only have one reasonable way to be
 performed, sunch as :class:`Func`, :class:`Error`, and :class:`Constant`.
 """
 
-
-from __future__ import print_function, absolute_import
-
 import time
 
 import attr

--- a/effect/_sync.py
+++ b/effect/_sync.py
@@ -31,7 +31,7 @@ def sync_perform(dispatcher, effect):
     if successes:
         return successes[0]
     elif errors:
-        six.reraise(*errors[0])
+        raise errors[0]
     else:
         raise NotSynchronousError("Performing %r was not synchronous!"
                                   % (effect,))
@@ -70,6 +70,6 @@ def sync_performer(f):
         pass_args = args[:-1]
         try:
             box.succeed(f(*pass_args, **kwargs))
-        except:
-            box.fail(sys.exc_info())
+        except Exception as e:
+            box.fail(e)
     return sync_wrapper

--- a/effect/_sync.py
+++ b/effect/_sync.py
@@ -4,7 +4,6 @@
 Tools for dealing with Effects synchronously.
 """
 
-import six
 import sys
 
 from ._base import perform

--- a/effect/_sync.py
+++ b/effect/_sync.py
@@ -4,8 +4,6 @@
 Tools for dealing with Effects synchronously.
 """
 
-import sys
-
 from ._base import perform
 from ._utils import wraps
 

--- a/effect/_test_utils.py
+++ b/effect/_test_utils.py
@@ -1,6 +1,5 @@
 """Another sad little utility module."""
 
-import sys
 import traceback
 
 import attr
@@ -30,7 +29,7 @@ class MatchesException(object):
             return Mismatch('{} is not a {}'.format(other, expected_type))
         if other.args != self.expected.args:
             return Mismatch('{} has different arguments: {}.'.format(
-                    other.args, self.expected.args))
+                other.args, self.expected.args))
 
 
 @attr.s

--- a/effect/async.py
+++ b/effect/async.py
@@ -1,2 +1,0 @@
-from .parallel_async import perform_parallel_async
-__all__ = ['perform_parallel_async']

--- a/effect/do.py
+++ b/effect/do.py
@@ -95,7 +95,7 @@ def do_return(val):
 def _do(result, generator, is_error):
     try:
         if is_error:
-            val = generator.throw(*result)
+            val = generator.throw(result)
         else:
             val = generator.send(result)
     except StopIteration as stop:
@@ -104,8 +104,7 @@ def _do(result, generator, is_error):
         # case where some other code is raising StopIteration up through this
         # generator, in which case we shouldn't really treat it like a function
         # return -- it could quite easily hide bugs.
-        tb = sys.exc_info()[2]
-        if tb.tb_next:
+        if stop.__traceback__.tb_next:
             raise
         else:
             # Python 3 allows you to use `return val` in a generator, which

--- a/effect/do.py
+++ b/effect/do.py
@@ -7,7 +7,6 @@ See :func:`do`.
 
 from __future__ import print_function
 
-import sys
 import types
 
 from . import Effect, Func

--- a/effect/do.py
+++ b/effect/do.py
@@ -4,9 +4,6 @@ An imperative-looking notation for Effectful code.
 See :func:`do`.
 """
 
-
-from __future__ import print_function
-
 import types
 
 from . import Effect, Func

--- a/effect/fold.py
+++ b/effect/fold.py
@@ -9,15 +9,14 @@ class FoldError(Exception):
     Raised when one of the Effects passed to :func:`fold_effect` fails.
 
     :ivar accumulator: The data accumulated so far, before the failing Effect.
-    :ivar wrapped_exception: The exc_info tuple representing the original
-        exception raised by the failing Effect.
+    :ivar wrapped_exception: The original exception raised by the failing Effect.
     """
     def __init__(self, accumulator, wrapped_exception):
         self.accumulator = accumulator
         self.wrapped_exception = wrapped_exception
 
     def __str__(self):
-        tb_lines = traceback.format_exception(*self.wrapped_exception)
+        tb_lines = traceback.TracebackException.from_exception(self.wrapped_exception).format()
         tb = ''.join(tb_lines)
         st = (
             "<FoldError after accumulating %r> Original traceback follows:\n%s"

--- a/effect/io.py
+++ b/effect/io.py
@@ -6,7 +6,6 @@ Use :obj:`effect.io.stdio_dispatcher` as a dispatcher for :obj:`Display` and
 
 from __future__ import print_function
 import attr
-from six.moves import input
 
 from . import sync_performer, TypeDispatcher
 
@@ -32,8 +31,7 @@ def perform_display_print(dispatcher, intent):
 @sync_performer
 def perform_get_input_raw_input(dispatcher, intent):
     """
-    Perform a :obj:`Prompt` intent by using ``raw_input`` (or ``input`` on
-    Python 3).
+    Perform a :obj:`Prompt` intent by using ``input``.
     """
     return input(intent.prompt)
 

--- a/effect/io.py
+++ b/effect/io.py
@@ -4,7 +4,6 @@ Use :obj:`effect.io.stdio_dispatcher` as a dispatcher for :obj:`Display` and
 :obj:`Prompt` that uses built-in Python standard io facilities.
 """
 
-from __future__ import print_function
 import attr
 
 from . import sync_performer, TypeDispatcher

--- a/effect/parallel_async.py
+++ b/effect/parallel_async.py
@@ -28,9 +28,7 @@ def perform_parallel_async(dispatcher, intent, box):
             box.succeed(results)
 
     def fail(index, result):
-        box.fail((FirstError,
-                  FirstError(exc_info=result, index=index),
-                  result[2]))
+        box.fail(FirstError(exception=result, index=index))
 
     for index, effect in enumerate(effects):
         perform(

--- a/effect/retry.py
+++ b/effect/retry.py
@@ -14,7 +14,7 @@ def retry(effect, should_retry):
     will fail with the most recent error from func.
 
     :param effect.Effect effect: Any effect.
-    :param should_retry: A function which should take an exc_info tuple as an
+    :param should_retry: A function which should take an exception as an
         argument and return an effect of bool.
     """
 
@@ -22,7 +22,7 @@ def retry(effect, should_retry):
         if retry_allowed:
             return try_()
         else:
-            six.reraise(*error)
+            raise error
 
     def try_():
         return effect.on(

--- a/effect/retry.py
+++ b/effect/retry.py
@@ -1,7 +1,5 @@
 """Retrying effects."""
 
-import six
-
 from functools import partial
 
 

--- a/effect/test_async.py
+++ b/effect/test_async.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from testtools.testcase import TestCase
 
 from ._base import Effect, perform

--- a/effect/test_base.py
+++ b/effect/test_base.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, absolute_import
 
-import sys
 import traceback
 
 from testtools import TestCase

--- a/effect/test_base.py
+++ b/effect/test_base.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import
-
 import traceback
 
 from testtools import TestCase

--- a/effect/test_do.py
+++ b/effect/test_do.py
@@ -82,12 +82,12 @@ def test_raise_from_effect():
     def f():
         try:
             yield Effect(Error(ZeroDivisionError('foo')))
-        except:
-            got_error = sys.exc_info()
+        except Exception as e:
+            got_error = e
         yield do_return(got_error)
 
-    exc_type, exc, _ = perf(f())
-    assert exc_type is ZeroDivisionError
+    exc = perf(f())
+    assert type(exc) is ZeroDivisionError
     assert str(exc) == 'foo'
 
 

--- a/effect/test_do.py
+++ b/effect/test_do.py
@@ -4,8 +4,6 @@ from functools import partial
 from py.test import raises as raises
 from py.test import mark
 
-import six
-
 from . import (
     ComposedDispatcher, Constant, Effect, Error, TypeDispatcher,
     base_dispatcher, sync_perform, sync_performer)
@@ -170,7 +168,6 @@ def test_stop_iteration_only_local():
             perf(eff)
 
 
-@mark.skipif(not six.PY3, reason="Testing a Py3-specific feature")
 def test_py3_return():
     """The `return x` syntax in Py3 sets the result of the Effect to `x`."""
     from effect._test_do_py3 import py3_generator_with_return

--- a/effect/test_do.py
+++ b/effect/test_do.py
@@ -1,8 +1,7 @@
 import sys
 from functools import partial
 
-from py.test import raises as raises
-from py.test import mark
+from py.test import raises
 
 from . import (
     ComposedDispatcher, Constant, Effect, Error, TypeDispatcher,

--- a/effect/test_fold.py
+++ b/effect/test_fold.py
@@ -2,10 +2,12 @@
 import operator
 
 from pytest import raises
+from testtools.assertions import assert_that
 
 from effect import Effect, Error, base_dispatcher, sync_perform
 from effect.fold import FoldError, fold_effect, sequence
 from effect.testing import perform_sequence
+from ._test_utils import MatchesException
 
 
 def test_fold_effect():
@@ -48,8 +50,7 @@ def test_fold_effect_errors():
     with raises(FoldError) as excinfo:
         perform_sequence(dispatcher, eff)
     assert excinfo.value.accumulator == 'NilEi'
-    assert excinfo.value.wrapped_exception[0] is ZeroDivisionError
-    assert str(excinfo.value.wrapped_exception[1]) == 'foo'
+    assert_that(excinfo.value.wrapped_exception, MatchesException(ZeroDivisionError('foo')))
 
 
 def test_fold_effect_str():
@@ -98,5 +99,4 @@ def test_sequence_error():
     with raises(FoldError) as excinfo:
         perform_sequence(dispatcher, eff)
     assert excinfo.value.accumulator == ['Ei']
-    assert excinfo.value.wrapped_exception[0] is ZeroDivisionError
-    assert str(excinfo.value.wrapped_exception[1]) == 'foo'
+    assert_that(excinfo.value.wrapped_exception, MatchesException(ZeroDivisionError('foo')))

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import
-
 from functools import partial
 
 from testtools import TestCase

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -2,8 +2,6 @@ from __future__ import print_function, absolute_import
 
 from functools import partial
 
-import six
-
 from testtools import TestCase
 from testtools.matchers import Equals, MatchesListwise
 

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -9,7 +9,7 @@ from testtools.matchers import Equals, MatchesListwise
 
 from pytest import raises
 
-from ._base import Effect
+from ._base import Effect, raise_
 from ._dispatcher import ComposedDispatcher, TypeDispatcher
 from ._intents import (
     base_dispatcher,
@@ -20,7 +20,7 @@ from ._intents import (
     FirstError,
     ParallelEffects, parallel_all_errors)
 from ._sync import sync_perform
-from ._test_utils import MatchesReraisedExcInfo, get_exc_info
+from ._test_utils import MatchesReraisedExcInfo
 from .parallel_async import perform_parallel_async
 from .test_parallel_performers import EquitableException
 
@@ -59,8 +59,7 @@ def test_perform_func_args_kwargs():
 
 def test_first_error_str():
     """FirstErrors have a pleasing format."""
-    fe = FirstError(exc_info=(ValueError, ValueError('foo'), None),
-                    index=150)
+    fe = FirstError(ValueError('foo'), index=150)
     assert str(fe) == '(index=150) ValueError: foo'
 
 
@@ -78,13 +77,13 @@ class ParallelAllErrorsTests(TestCase):
 
     def test_parallel_all_errors(self):
         """
-        Exceptions raised from child effects get turned into (True, exc_info)
+        Exceptions raised from child effects get turned into (True, exc)
         results.
         """
-        exc_info1 = get_exc_info(EquitableException(message='foo'))
-        reraise1 = partial(six.reraise, *exc_info1)
-        exc_info2 = get_exc_info(EquitableException(message='bar'))
-        reraise2 = partial(six.reraise, *exc_info2)
+        exc1 = EquitableException(message='foo')
+        reraise1 = partial(raise_, exc1)
+        exc2 = EquitableException(message='bar')
+        reraise2 = partial(raise_, exc2)
 
         dispatcher = ComposedDispatcher([
             TypeDispatcher({
@@ -99,8 +98,8 @@ class ParallelAllErrorsTests(TestCase):
             sync_perform(dispatcher, eff),
             MatchesListwise([
                 MatchesListwise([Equals(True),
-                                 MatchesReraisedExcInfo(exc_info1)]),
+                                 MatchesReraisedExcInfo(exc1)]),
                 Equals((False, 1)),
                 MatchesListwise([Equals(True),
-                                 MatchesReraisedExcInfo(exc_info2)]),
+                                 MatchesReraisedExcInfo(exc2)]),
             ]))

--- a/effect/test_io.py
+++ b/effect/test_io.py
@@ -13,6 +13,6 @@ def test_perform_display_print(capsys):
 def test_perform_get_input_raw_input(monkeypatch):
     """The stdio dispatcher has a performer that reads input."""
     monkeypatch.setattr(
-        'effect.io.input',
+        'builtins.input',
         lambda p: 'my name' if p == '> ' else 'boo')
     assert sync_perform(stdio_dispatcher, Effect(Prompt('> '))) == 'my name'

--- a/effect/test_parallel_performers.py
+++ b/effect/test_parallel_performers.py
@@ -6,10 +6,10 @@ import six
 
 from testtools.matchers import MatchesStructure, Equals
 
-from . import Effect
+from . import Effect, raise_
 from ._intents import Constant, Func, FirstError, parallel
 from ._sync import sync_perform
-from ._test_utils import MatchesReraisedExcInfo, get_exc_info
+from ._test_utils import MatchesReraisedExcInfo
 
 
 @attr.s(hash=True)
@@ -46,8 +46,8 @@ class ParallelPerformerTestsMixin(object):
         When given an effect that results in a Error,
         ``perform_parallel_async`` result in ``FirstError``.
         """
-        expected_exc_info = get_exc_info(EquitableException(message='foo'))
-        reraise = partial(six.reraise, *expected_exc_info)
+        expected_exc = EquitableException(message='foo')
+        reraise = partial(raise_, expected_exc)
         try:
             sync_perform(
                 self.dispatcher,
@@ -57,7 +57,7 @@ class ParallelPerformerTestsMixin(object):
                 fe,
                 MatchesStructure(
                     index=Equals(0),
-                    exc_info=MatchesReraisedExcInfo(expected_exc_info)))
+                    exception=MatchesReraisedExcInfo(expected_exc)))
         else:
             self.fail("sync_perform should have raised FirstError.")
 
@@ -66,8 +66,8 @@ class ParallelPerformerTestsMixin(object):
         The ``index`` of a :obj:`FirstError` is the index of the effect that
         failed in the list.
         """
-        expected_exc_info = get_exc_info(EquitableException(message='foo'))
-        reraise = partial(six.reraise, *expected_exc_info)
+        expected_exc = EquitableException(message='foo')
+        reraise = partial(raise_, expected_exc)
         try:
             sync_perform(
                 self.dispatcher,
@@ -80,4 +80,4 @@ class ParallelPerformerTestsMixin(object):
                 fe,
                 MatchesStructure(
                     index=Equals(1),
-                    exc_info=MatchesReraisedExcInfo(expected_exc_info)))
+                    exception=MatchesReraisedExcInfo(expected_exc)))

--- a/effect/test_parallel_performers.py
+++ b/effect/test_parallel_performers.py
@@ -2,8 +2,6 @@ from functools import partial
 
 import attr
 
-import six
-
 from testtools.matchers import MatchesStructure, Equals
 
 from . import Effect, raise_

--- a/effect/test_retry.py
+++ b/effect/test_retry.py
@@ -53,7 +53,7 @@ class RetryTests(TestCase):
             lambda: raise_(RuntimeError("3")))
 
         def should_retry(e):
-            return ESConstant(str(e[1]) != "3")
+            return ESConstant(str(e) != "3")
 
         result = retry(ESFunc(func), should_retry)
         self.assertThat(lambda: resolve_stubs(base_dispatcher, result),

--- a/effect/test_sync.py
+++ b/effect/test_sync.py
@@ -1,10 +1,11 @@
 from functools import partial
 
 from testtools import TestCase
-from testtools.matchers import MatchesException, raises
+from testtools.matchers import raises
 
 from ._base import Effect
 from ._sync import NotSynchronousError, sync_perform, sync_performer
+from ._test_utils import MatchesException
 
 
 def func_dispatcher(intent):
@@ -38,7 +39,7 @@ class SyncPerformTests(TestCase):
         sync_perform.
         """
         def fail(box):
-            box.fail((ValueError, ValueError("oh dear"), None))
+            box.fail(ValueError("oh dear"))
         self.assertThat(
             lambda: sync_perform(func_dispatcher, Effect(fail)),
             raises(ValueError('oh dear')))

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -7,8 +7,7 @@ import attr
 import pytest
 
 from testtools import TestCase
-from testtools.matchers import (MatchesListwise, Equals, MatchesException,
-                                raises)
+from testtools.matchers import MatchesListwise, Equals, raises
 
 from . import (
     ComposedDispatcher,
@@ -37,6 +36,7 @@ from .testing import (
     perform_sequence,
     resolve_effect,
     resolve_stubs)
+from ._test_utils import MatchesException
 
 
 class ResolveEffectTests(TestCase):
@@ -123,7 +123,7 @@ class ResolveEffectTests(TestCase):
                 'result'),
             MatchesListwise([
                 Equals('handled'),
-                MatchesException(ZeroDivisionError)]))
+                MatchesException(ZeroDivisionError('division by zero'))]))
 
     def test_raise_if_final_result_is_error(self):
         """
@@ -466,7 +466,7 @@ def test_parallel_sequence_must_be_parallel():
     p = sequence([Effect(1), Effect(2), Effect(3)])
     with pytest.raises(FoldError) as excinfo:
         perform_sequence(seq, p)
-    assert excinfo.value.wrapped_exception[0] is AssertionError
+    assert type(excinfo.value.wrapped_exception) is AssertionError
 
 
 def test_nested_sequence():

--- a/effect/test_threads.py
+++ b/effect/test_threads.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from functools import partial
 
 from multiprocessing.pool import ThreadPool

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 from contextlib import contextmanager
 from functools import partial
 from operator import attrgetter
-import sys
 
 import attr
 

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -17,7 +17,6 @@ from ._base import Effect, guard, _Box, NoPerformerFoundError, raise_
 from ._sync import NotSynchronousError, sync_perform, sync_performer
 from ._intents import Constant, Error, Func, ParallelEffects, base_dispatcher
 
-import six
 
 __all__ = [
     'perform_sequence',

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -251,7 +251,7 @@ def resolve_effect(effect, result, is_error=False):
 
     :param result: If ``is_error`` is False, this can be any object and will be
         treated as the result of the effect. If ``is_error`` is True, this must
-        be a three-tuple in the style of ``sys.exc_info``.
+        be an exception.
     """
     for i, (callback, errback) in enumerate(effect.callbacks):
         cb = errback if is_error else callback
@@ -263,7 +263,7 @@ def resolve_effect(effect, result, is_error=False):
                 result.intent,
                 callbacks=result.callbacks + effect.callbacks[i + 1:])
     if is_error:
-        six.reraise(*result)
+        raise result
     return result
 
 
@@ -273,8 +273,8 @@ def fail_effect(effect, exception):
     """
     try:
         raise exception
-    except:
-        return resolve_effect(effect, sys.exc_info(), is_error=True)
+    except Exception as e:
+        return resolve_effect(effect, e, is_error=True)
 
 
 def resolve_stub(dispatcher, effect):

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -4,8 +4,6 @@ Various functions and dispatchers for testing effects.
 Usually the best way to test effects is by using :func:`perform_sequence`.
 """
 
-from __future__ import print_function
-
 from contextlib import contextmanager
 from functools import partial
 from operator import attrgetter

--- a/effect/threads.py
+++ b/effect/threads.py
@@ -1,7 +1,5 @@
 import sys
 
-import six
-
 from ._intents import FirstError
 from ._sync import sync_perform, sync_performer
 
@@ -36,9 +34,6 @@ def perform_parallel_with_pool(pool, dispatcher, parallel_effects):
         index, effect = index_and_effect
         try:
             return sync_perform(dispatcher, effect)
-        except:
-            exc_info = sys.exc_info()
-            six.reraise(FirstError,
-                        FirstError(exc_info=exc_info, index=index),
-                        exc_info[2])
+        except Exception as e:
+            raise FirstError(exception=e, index=index)
     return pool.map(perform_child, enumerate(parallel_effects.effects))

--- a/effect/threads.py
+++ b/effect/threads.py
@@ -1,5 +1,3 @@
-import sys
-
 from ._intents import FirstError
 from ._sync import sync_perform, sync_performer
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@
 universal=1
 
 [flake8]
-max-line-length = 88
+max-line-length = 100
+ignore = E131,E301,E302,E731,W503,E701,E704,E722

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[flake8]
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         ],
     packages=['effect'],
-    install_requires=['six', 'attrs'],
+    install_requires=['attrs'],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,4 @@ setuptools.setup(
         ],
     packages=['effect'],
     install_requires=['six', 'attrs'],
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setuptools.setup(
     license="MIT",
     classifiers=[
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         ],
     packages=['effect'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        ],
+    ],
     packages=['effect'],
     install_requires=['attrs'],
 )


### PR DESCRIPTION
Fixes #24 (Passing around exc_info tuples sucks)

Ripping off the bandaid:

- this PR makes Effect only support Python 3
- this PR changes the API of Effect in a completely backwards-incompatible way

Everywhere where we used to deal with exc_info tuples, we now use Exception instances. This works in Python3 because Exception instances carry around their tracebacks.