### PR TITLE
docs: Fix a few typos

### DIFF
--- a/effect/_base.py
+++ b/effect/_base.py
@@ -163,7 +163,7 @@ def catch(exc_type, callable):
                            lambda exc: "got an error!"))
 
     If any exception other than a ``SpecificException`` is thrown, it will be
-    ignored by this handler and propogate further down the chain of callbacks.
+    ignored by this handler and propagate further down the chain of callbacks.
     """
 
     def catcher(error):

--- a/effect/fold.py
+++ b/effect/fold.py
@@ -73,7 +73,7 @@ def sequence(effects):
         fails.
     """
     # Could be: folder = lambda acc, el: acc + [el]
-    # But, for peformance:
+    # But, for performance:
     result = []
 
     def folder(acc, el):

--- a/effect/test_base.py
+++ b/effect/test_base.py
@@ -107,7 +107,7 @@ class EffectPerformTests(TestCase):
 
     def test_success_propagates_effect_exception(self):
         """
-        If an succes callback is specified, but a exception result occurs,
+        If an success callback is specified, but a exception result occurs,
         the exception is passed to the next callback.
         """
         calls = []
@@ -124,7 +124,7 @@ class EffectPerformTests(TestCase):
 
     def test_error_propagates_effect_result(self):
         """
-        If an error callback is specified, but a succesful result occurs,
+        If an error callback is specified, but a successful result occurs,
         the success is passed to the next callback.
         """
         calls = []

--- a/effect/test_parallel_performers.py
+++ b/effect/test_parallel_performers.py
@@ -21,7 +21,7 @@ class ParallelPerformerTestsMixin(object):
     def test_empty(self):
         """
         When given an empty list of effects, ``perform_parallel_async`` returns
-        an empty list synchronusly.
+        an empty list synchronously.
         """
         result = sync_perform(self.dispatcher, parallel([]))
         self.assertEqual(result, [])


### PR DESCRIPTION
There are small typos in:
- effect/_base.py
- effect/fold.py
- effect/test_base.py
- effect/test_parallel_performers.py

Fixes:
- Should read `synchronously` rather than `synchronusly`.
- Should read `successful` rather than `succesful`.
- Should read `success` rather than `succes`.
- Should read `propagate` rather than `propogate`.
- Should read `performance` rather than `peformance`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md